### PR TITLE
Database files larger than 2GB

### DIFF
--- a/src/filemgr_ops_windows.cc
+++ b/src/filemgr_ops_windows.cc
@@ -128,7 +128,7 @@ int _filemgr_win_close(int fd)
 cs_off_t _filemgr_win_goto_eof(int fd)
 {
 #ifdef _MSC_VER
-    cs_off_t rv = _lseek(fd, 0, SEEK_END);
+    cs_off_t rv = _lseeki64(fd, 0, SEEK_END);
     if (rv < 0) {
         return (cs_off_t) FDB_RESULT_SEEK_FAIL;
     }


### PR DESCRIPTION
Database files larger than 2GB do not work on Windows as the 32bit version of the seek function returns a signed long, which causes downstream functions to fail as the offsets are no longer valid.