### PR TITLE
libmusl compatibility

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -332,7 +332,11 @@
             (pthread_spin_trylock(arg) == 0)
         #define spin_unlock(arg) pthread_spin_unlock(arg)
         #define spin_destroy(arg) pthread_spin_destroy(arg)
-        #define SPIN_INITIALIZER (spin_t)(1)
+        #ifdef __GLIBC__
+            #define SPIN_INITIALIZER (spin_t)(1)
+        #else
+            #define SPIN_INITIALIZER (spin_t)(0)
+        #endif
     #endif
     #ifndef mutex_t
         // mutex
@@ -352,7 +356,12 @@
         #define thread_t pthread_t
         #define thread_cond_t pthread_cond_t
         #define thread_create(tid, func, args) \
-            pthread_create((tid), NULL, (func), (args))
+            { \
+            pthread_attr_t attr; \
+            pthread_attr_init(&attr); \
+            pthread_attr_setstacksize(&attr, 2097152); \
+            pthread_create((tid), &attr, (func), (args)); \
+            }
         #define thread_join(tid, ret) pthread_join(tid, ret)
         #define thread_cancel(tid) pthread_cancel(tid)
         #define thread_exit(code) pthread_exit(code)


### PR DESCRIPTION
I'm working on compiling couchbase on alpine linux. There were just two changes needed to get forestdb to successfully run all tests:

### spin_t
The existing code doesn't call `spin_init()` for some (most?) `spin_t` variables. The code works fine, however, since `SPIN_INITIALIZER` seems to be properly 'initializing' them. This is not the case when running on libmusl though, and calling `spin_lock()` on such 'initialized' `spin_t`'s leads to a deadlock.

While the proper solution would entail properly initializing all `spin_t` variables by calling `spin_init()`, I'm reluctant to do so, as there's no clear place where this can be done. Instead, setting the initializer to the correct value for musl `(spin_t)(0)` instead of `(spin_t)(1)` does the trick.

### pthread stack
Threads are crashing since the default musl pthread stack size is only 80k as opposed to the 2Mb when running on glibc. So I'm explicitly setting the stack size to 2Mb.

Change-Id: I02f7f4123a8d46d0ce1cef2285ac8fcefe02dc0d